### PR TITLE
fix: Optimize the visibility of images in dark theme

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,8 +13,9 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Primary Logo'}
 					description={'Our default, full-color landscape logo only ever appears\non white background.'}>
-					<div className={'my-6 lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
+							style={{backgroundColor: 'white'}}
 							objectFit={'contain'}
 							src={'/index/logo_primary.svg'}
 							width={560}
@@ -32,7 +33,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'White logo on dark background'}
 					description={'In cases where the logo appears on a dark background,\nuse the white logo version.'}>
-					<div className={'my-6 lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
 							objectFit={'contain'}
 							src={'/index/logo_black_background.svg'}
@@ -48,8 +49,9 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Black logo on white background'}
 					description={'In cases where the logo cannot be printed in full colour\nuse the black logo version.'}>
-					<div className={'my-6 lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
+							style={{backgroundColor: 'white'}}
 							objectFit={'contain'}
 							src={'/index/logo_white_background.svg'}
 							width={560}
@@ -66,7 +68,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Clearspace'}
 					description={'Our logo should always be prominent and legible. The clear space exists to prevent other elements from being placed too close.\nClear space is equal to x1 Yearn symbol.'}>
-					<div className={'mt-6 md:my-6 lg:h-[315px]'}>
+					<div className={'mt-6 text-center md:my-6 lg:h-[315px]'}>
 						<Image
 							objectFit={'contain'}
 							src={'/index/logo_clearspace.svg'}
@@ -78,7 +80,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Minimum size'}
 					description={'The minimum recommended size of the logo is 85 pixels wide (on screen) or 30mm wide (in print).\n​'}>
-					<div className={'mt-6 md:my-6 lg:h-[315px]'}>
+					<div className={'mt-6 text-center md:my-6 lg:h-[315px]'}>
 						<Image
 							objectFit={'contain'}
 							src={'/index/logo_minimum_size.svg'}
@@ -96,8 +98,9 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Primary Symbol'}
 					description={'Our default, full-color symbol only ever appears\non white background.'}>
-					<div className={'my-6 lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
+							style={{backgroundColor: 'white'}}
 							objectFit={'contain'}
 							src={'/index/symbol.svg'}
 							width={560}
@@ -115,7 +118,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'White symbol on dark background'}
 					description={'In cases where the symbol appears on a dark background,\nuse the white symbol version.'}>
-					<div className={'my-6 lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
 							objectFit={'contain'}
 							src={'/index/symbol_black_background.svg'}
@@ -131,8 +134,9 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Black symbol on white background'}
 					description={'In cases where the symbol cannot be printed in full colour\nuse the black symbol version.'}>
-					<div className={'my-6 bg-white lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
+							style={{backgroundColor: 'white'}}
 							objectFit={'contain'}
 							src={'/index/symbol_white_background.svg'}
 							width={560}
@@ -149,7 +153,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Clearspace'}
 					description={'Our symbol should always be prominent and legible. The clear space exists to prevent other elements from being placed too close.\nClear space is equal to x1 Yearn symbol.'}>
-					<div className={'mt-6 md:my-6 lg:h-[315px]'}>
+					<div className={'mt-6 text-center md:my-6 lg:h-[315px]'}>
 						<Image
 							objectFit={'cover'}
 							src={'/index/symbol_clearspace.svg'}
@@ -161,7 +165,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Minimum size'}
 					description={'The minimum recommended size of the symbol is 40 pixels wide (on screen) or 15mm wide (in print).\n\n'}>
-					<div className={'mt-6 md:my-6 lg:h-[315px]'}>
+					<div className={'mt-6 text-center md:my-6 lg:h-[315px]'}>
 						<Image
 							objectFit={'cover'}
 							src={'/index/symbol_minimum_size.svg'}
@@ -180,8 +184,9 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={'Token'}
 					description={'Our full-color token symbol can also be used as our social avatar.'}>
-					<div className={'my-6 bg-white lg:h-[315px]'}>
+					<div className={'my-6 text-center lg:h-[315px]'}>
 						<Image
+							style={{backgroundColor: 'white'}}
 							objectFit={'cover'}
 							src={'/index/token_symbol.svg'}
 							width={560}
@@ -196,7 +201,7 @@ function	Index(): ReactElement {
 				<ContentCard
 					title={''}
 					description={''}>
-					<div className={'mb-6 md:mt-20 lg:h-[315px]'}>
+					<div className={'mb-6 text-center md:mt-20 lg:h-[315px]'}>
 						<Image
 							objectFit={'cover'}
 							src={'/index/token_symbol_grid.svg'}


### PR DESCRIPTION
## Description

This PR fixes a bug that happens when using the dark theme in browsers.

Add white background property to images of logo and dark symbols so they can be viewed properly with dark theme. Also centered images on small screens.

## Related Issue

N/A

## Motivation and Context

When visiting the `Logo & Symbols` section on the homepage  with a browser using dark theme, some of the images that show the logo or symbols are not properly visible. The motivation is improve the appearance and experience of users with dark theme enabled in their browsers. 

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed things appeared as expected and checked that changes had no impact on the properties of download images. 

## Screenshots (if appropriate):

Image on the left show before, image on the right shows after

![dark-theme-issues](https://user-images.githubusercontent.com/104786213/215140082-af698d79-e0d3-4226-9515-260aa52a8d03.jpg)

